### PR TITLE
 issue-2: adjust "now" to avoid floating point issues; fix a typo

### DIFF
--- a/spec/redis_gcra_spec.rb
+++ b/spec/redis_gcra_spec.rb
@@ -72,12 +72,12 @@ describe RedisGCRA do
     end
 
     test_cases = [
-      { burst: 1000, rate: 100, period: 60, cost: 2,    repeat: 1, expected_remainign: 998 },
-      { burst: 1000, rate: 100, period: 60, cost: 200,  repeat: 1, expected_remainign: 800 },
-      { burst: 1000, rate: 100, period: 60, cost: 200,  repeat: 4, expected_remainign: 200 },
-      { burst: 1000, rate: 100, period: 60, cost: 200,  repeat: 5, expected_remainign: 0 },
-      { burst: 1000, rate: 100, period: 60, cost: 1,    repeat: 137, expected_remainign: 863 },
-      { burst: 1000, rate: 100, period: 60, cost: 1001, repeat: 1, expected_remainign: 0 }
+      { burst: 1000, rate: 100, period: 60, cost: 2,    repeat: 1, expected_remaining: 998 },
+      { burst: 1000, rate: 100, period: 60, cost: 200,  repeat: 1, expected_remaining: 800 },
+      { burst: 1000, rate: 100, period: 60, cost: 200,  repeat: 4, expected_remaining: 200 },
+      { burst: 1000, rate: 100, period: 60, cost: 200,  repeat: 5, expected_remaining: 0 },
+      { burst: 1000, rate: 100, period: 60, cost: 1,    repeat: 137, expected_remaining: 863 },
+      { burst: 1000, rate: 100, period: 60, cost: 1001, repeat: 1, expected_remaining: 0 }
     ]
 
     test_cases.each_with_index do |test_case, index|
@@ -91,7 +91,7 @@ describe RedisGCRA do
           )
         end.last
 
-        expect(result.remaining).to eq(test_case[:expected_remainign])
+        expect(result.remaining).to eq(test_case[:expected_remaining])
       end
     end
   end

--- a/vendor/inspect_gcra_ratelimit.lua
+++ b/vendor/inspect_gcra_ratelimit.lua
@@ -8,9 +8,14 @@ local burst_offset = emission_interval * burst
 local now = redis.call("TIME")
 
 -- redis returns time as an array containing two integers: seconds of the epoch
--- time and microseconds. for convenience we need to convert them to float
--- point number
-now = now[1] + now[2] / 1000000
+-- time (10 digits) and microseconds (6 digits). for convenience we need to
+-- convert them to a floating point number. the resulting number is 16 digits,
+-- bordering on the limits of a 64-bit double-precision floating point number.
+-- adjust the epoch to be relative to Jan 1, 2017 00:00:00 GMT to avoid floating
+-- point problems. this approach is good until "now" is 2,483,228,799 (Wed, 09
+-- Sep 2048 01:46:39 GMT), when the adjusted value is 16 digits.
+local jan_1_2017 = 1483228800
+now = (now[1] - jan_1_2017) + (now[2] / 1000000)
 
 local tat = redis.call("GET", rate_limit_key)
 

--- a/vendor/perform_gcra_ratelimit.lua
+++ b/vendor/perform_gcra_ratelimit.lua
@@ -13,9 +13,14 @@ local burst_offset = emission_interval * burst
 local now = redis.call("TIME")
 
 -- redis returns time as an array containing two integers: seconds of the epoch
--- time and microseconds. for convenience we need to convert them to float
--- point number
-now = now[1] + now[2] / 1000000
+-- time (10 digits) and microseconds (6 digits). for convenience we need to
+-- convert them to a floating point number. the resulting number is 16 digits,
+-- bordering on the limits of a 64-bit double-precision floating point number.
+-- adjust the epoch to be relative to Jan 1, 2017 00:00:00 GMT to avoid floating
+-- point problems. this approach is good until "now" is 2,483,228,799 (Wed, 09
+-- Sep 2048 01:46:39 GMT), when the adjusted value is 16 digits.
+local jan_1_2017 = 1483228800
+now = (now[1] - jan_1_2017) + (now[2] / 1000000)
 
 local tat = redis.call("GET", rate_limit_key)
 


### PR DESCRIPTION
1) fix a problem where converting the epoch (date/time and microseconds)
borders on the limits of a 64-bit double-precision floating point number;
the resulting value is adjusted relative to January 1, 2017.
2) correct a typo.